### PR TITLE
Add alpha on clear color

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ Scene.prototype.draw = function (camera) {
 
   self.gl.enable(self.gl.DEPTH_TEST)
   if (self.background) {
-    self.gl.clearColor(self.background[0], self.background[1], self.background[2], 1)
+    self.gl.clearColor(self.background[0], self.background[1], self.background[2], self.background[3] === undefined ? 1 : self.background[3])
     self.gl.clear(self.gl.COLOR_BUFFER_BIT | self.gl.DEPTH_BUFFER_BIT)
   }
 


### PR DESCRIPTION
I change the background color to allow user to set alpha on the background.
By default the alpha is 1.